### PR TITLE
Provide cache invalidation information.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
+var stringify = require('json-stable-stringify');
+
 module.exports = function(filteredImports) {
-  return function(babel) {
+  function babelPluginFilterImports(babel) {
     // A stack of booleans that determine whether an expression statement
     // should be removed as it is exited. Expression statements are removed
     // when they contain a reference to a filtered imported.
@@ -36,6 +38,16 @@ module.exports = function(filteredImports) {
       }
     });
   };
+
+  babelPluginFilterImports.baseDir = function() {
+    return __dirname;
+  };
+
+  babelPluginFilterImports.cacheKey = function() {
+    return stringify(filteredImports);
+  };
+
+  return babelPluginFilterImports;
 };
 
 function referencesFilteredImport(identifier, filteredImports) {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "babel-core": "^5.5.3",
     "mocha": "^2.2.5"
+  },
+  "dependencies": {
+    "json-stable-stringify": "^1.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -31,4 +31,19 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('partial-filter-1', { assert: ['default'], cloud: ['default'] });
   testFixture('partial-filter-2', { assert: ['a', 'c'] });
   testFixture('partial-filter-3', { assert: ['a', 'c'] });
+
+  it('provides a baseDir', function() {
+    var expectedPath = path.join(__dirname, '..');
+
+    var instance = filterImports({ assert: ['default'] });
+
+    assert.equal(instance.baseDir(), expectedPath);
+  });
+
+  it('includes options in `cacheKey`', function() {
+    var first = filterImports({ assert: ['default'] });
+    var second = filterImports({ assert: ['assert'] });
+
+    assert.notEqual(first.cacheKey(), second.cacheKey());
+  });
 });


### PR DESCRIPTION
This goes along with https://github.com/babel/broccoli-babel-transpiler/pull/89.

See additional related PR's:

* https://github.com/babel/broccoli-babel-transpiler/pull/89
* https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/pull/34
* https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/pull/15
* https://github.com/ember-cli/babel-plugin-feature-flags/pull/12
* https://github.com/ember-cli/ember-cli-htmlbars/pull/90
* https://github.com/offirgolan/ember-cp-validations/pull/305

Note: this PR is against a new v0.2.x branch created.  Once we move to babel 6 here, this code is no longer needed because the default babel 6 options passing mechanism "just works" for us.