### PR TITLE
fix(remove): remove only body on `ArrowFunctionExpression`

### DIFF
--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -9,6 +9,10 @@ const removeReferences = (path, specifier) => {
   _.forEach(referencePaths, referencePath => {
     const parent = referencePath.findParent(isRemovablePath)
 
+    if (t.isArrowFunctionExpression(parent)) {
+      parent.get('body').remove()
+      return
+    }
     if (t.isVariableDeclarator(parent)) removeReferences(parent, _.get(parent, 'node.id.name'))
     parent.remove()
   })

--- a/test/fixtures/return/expected.js
+++ b/test/fixtures/return/expected.js
@@ -1,4 +1,5 @@
 const butter = () => {};
 export const cloud = function () {};
 export const doom = () => {};
-export const egg;
+export const egg = () => {};
+export const food = () => {};

--- a/test/fixtures/return/fixture.js
+++ b/test/fixtures/return/fixture.js
@@ -10,3 +10,4 @@ export const doom = () => {
   return a.ok();
 }
 export const egg = () => a.ok();
+export const food = () => (a.ok());


### PR DESCRIPTION
# Applied change

This PR allow to remove only body of  `ArrowFunctionExpression`, this means that `egg` will remain a valid function and can be callable.

### fixture

```js
import a from 'assert';

export const egg = () => a.ok();
```

### current

```js
import a from 'assert';

export const egg;
```

### expected

```js
import a from 'assert';

export const egg = () => {};
```