### PR TITLE
chore(package): update deps, switch to babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "4"
+      }
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-eslint": "^8.0.1",
+    "babel-preset-env": "^1.6.0",
     "babel-register": "^6.26.0",
     "eslint": "^4.6.1",
-    "eslint-config-prettier": "^2.4.0",
-    "eslint-plugin-prettier": "^2.2.0",
-    "mocha": "^3.5.0",
-    "prettier": "^1.6.1",
-    "rimraf": "^2.6.1"
+    "eslint-config-prettier": "^2.6.0",
+    "eslint-plugin-prettier": "^2.3.1",
+    "mocha": "^3.5.3",
+    "prettier": "^1.7.0",
+    "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
This PR:
- updates all deps
- switches to `babel-preset-env` because `babel-preset-es2015` was deprecated