### PR TITLE
fix(plugin): fix the case of directly nested call expressions

### DIFF
--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -8,6 +8,7 @@ const removeReferences = (path, specifier) => {
 
   _.forEach(referencePaths, referencePath => {
     const parent = referencePath.findParent(isRemovablePath)
+    if (parent.removed) return;
 
     if (t.isArrowFunctionExpression(parent)) {
       parent.get('body').remove()

--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -8,8 +8,8 @@ const removeReferences = (path, specifier) => {
 
   _.forEach(referencePaths, referencePath => {
     const parent = referencePath.findParent(isRemovablePath)
-    if (parent.removed) return;
 
+    if (parent.removed) return
     if (t.isArrowFunctionExpression(parent)) {
       parent.get('body').remove()
       return

--- a/test/fixtures/nested-calls/expected.js
+++ b/test/fixtures/nested-calls/expected.js
@@ -1,0 +1,3 @@
+import c from 'cloud';
+
+c();

--- a/test/fixtures/nested-calls/fixture.js
+++ b/test/fixtures/nested-calls/fixture.js
@@ -1,3 +1,8 @@
 import { a, b } from 'assert';
+import c from 'cloud';
 
-a(b());
+a(b())
+a(b(), c)
+a(b(), c())
+
+c()

--- a/test/fixtures/nested-calls/fixture.js
+++ b/test/fixtures/nested-calls/fixture.js
@@ -1,0 +1,3 @@
+import { a, b } from 'assert';
+
+a(b());

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,7 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('callback', { assert: ['default'] })
   testFixture('declaration', { assert: ['default'] })
   testFixture('declaration-multiple', { assert: ['default'] })
+  testFixture('nested-calls', { assert: ['a', 'b'] })
   testFixture('nesting', { assert: ['default'] })
   testFixture('mixed', { assert: ['default', 'cloud'] })
   testFixture('return', { assert: ['default'] })


### PR DESCRIPTION
Fixes the case where call statements of stripped functions are nested directly:

```
import { a, b } from 'assert';

a(b());
```

This could possibly also be solved by adding `t.isCallExpression` to `isRemovablePath`, but I think that may be a bit too generic as it could result in breaking expression statements in general. This simply guards against the node already being removed.