### PR TITLE
feat(plugin): add support for stripping decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.26.0",
     "eslint": "^4.6.1",

--- a/src/isRemovablePath.js
+++ b/src/isRemovablePath.js
@@ -4,6 +4,7 @@ const isRemovablePath = path =>
   t.isArrowFunctionExpression(path) ||
   t.isExpressionStatement(path) ||
   t.isReturnStatement(path) ||
-  t.isVariableDeclarator(path)
+  t.isVariableDeclarator(path) ||
+  t.isDecorator(path)
 
 export default isRemovablePath

--- a/src/isRemovablePath.js
+++ b/src/isRemovablePath.js
@@ -2,9 +2,9 @@ import * as t from 'babel-types'
 
 const isRemovablePath = path =>
   t.isArrowFunctionExpression(path) ||
+  t.isDecorator(path) ||
   t.isExpressionStatement(path) ||
   t.isReturnStatement(path) ||
-  t.isVariableDeclarator(path) ||
-  t.isDecorator(path)
+  t.isVariableDeclarator(path)
 
 export default isRemovablePath

--- a/test/fixtures/decorator/expected.js
+++ b/test/fixtures/decorator/expected.js
@@ -1,4 +1,6 @@
-let Foo = class Foo {
+let Assert = class Assert {
   method() {}
+
+  multiple() {}
 };
-let Bar = class Bar {};
+let Butter = class Butter {};

--- a/test/fixtures/decorator/expected.js
+++ b/test/fixtures/decorator/expected.js
@@ -1,0 +1,4 @@
+let Foo = class Foo {
+  method() {}
+};
+let Bar = class Bar {};

--- a/test/fixtures/decorator/fixture.js
+++ b/test/fixtures/decorator/fixture.js
@@ -1,0 +1,11 @@
+import d from 'decorate';
+
+class Foo {
+  @d
+  method() {
+
+  }
+}
+
+@d
+class Bar {}

--- a/test/fixtures/decorator/fixture.js
+++ b/test/fixtures/decorator/fixture.js
@@ -1,11 +1,18 @@
-import d from 'decorate';
+import a from 'assert';
+import b from 'butter';
 
-class Foo {
-  @d
+class Assert {
+  @a
   method() {
+
+  }
+
+  @a
+  @b
+  multiple() {
 
   }
 }
 
-@d
-class Bar {}
+@a
+class Butter {}

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,7 @@ describe('babel-plugin-filter-imports', function() {
   ])
 
   testFixtureWithPlugins('decorator', [
-    [filterImports, { imports: { decorate: ['d'] } }],
+    [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
     'transform-decorators-legacy',
   ])
 })

--- a/test/test.js
+++ b/test/test.js
@@ -56,4 +56,9 @@ describe('babel-plugin-filter-imports', function() {
     [filterImports, { imports: { assert: ['default'] } }],
     [filterImports, { imports: { cloud: ['default'] } }],
   ])
+
+  testFixtureWithPlugins('decorator', [
+    [filterImports, { imports: { decorate: ['d'] } }],
+    'transform-decorators-legacy',
+  ])
 })


### PR DESCRIPTION
Adds support for stripping decorators, which will be useful now that the ES Class RFC is merged. This will allow us to write decorators that can do runtime checks/transformations of classes, methods, and fields such as type checking, but can then be stripped out of production builds.