### PR TITLE
feat(export): Adds support for filtering exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.26.0",
     "eslint": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/ember-cli/babel-plugin-filter-imports",
   "dependencies": {
+    "babel-plugin-syntax-export-extensions": "^6.13.0",
     "babel-types": "^6.26.0",
     "lodash": "^4.17.4"
   },
@@ -38,7 +39,6 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.26.0",
     "eslint": "^4.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import syntaxDecorators from 'babel-plugin-syntax-decorators'
-import syntaxExportExtensions from 'babel-plugin-syntax-export-extensions'
 import _ from 'lodash'
 import path from 'path'
 
@@ -7,9 +5,10 @@ import getSpecifiersForRemoval from './getSpecifierNames'
 import removeReferences from './removeReferences'
 
 module.exports = () => ({
-  inherits: syntaxDecorators,
-
-  inherits: syntaxExportExtensions,
+  manipulateOptions: (opts, parserOptions) => {
+    parserOptions.plugins.push('decorators')
+    parserOptions.plugins.push('exportExtensions')
+  },
 
   visitor: {
     ImportDeclaration: (path, { opts }) => {

--- a/src/isRemovablePath.js
+++ b/src/isRemovablePath.js
@@ -4,6 +4,7 @@ const isRemovablePath = path =>
   t.isArrowFunctionExpression(path) ||
   t.isExpressionStatement(path) ||
   t.isReturnStatement(path) ||
-  t.isVariableDeclarator(path)
+  t.isVariableDeclarator(path) ||
+  t.isExportSpecifier(path)
 
 export default isRemovablePath

--- a/src/isRemovablePath.js
+++ b/src/isRemovablePath.js
@@ -4,8 +4,8 @@ const isRemovablePath = path =>
   t.isArrowFunctionExpression(path) ||
   t.isDecorator(path) ||
   t.isExpressionStatement(path) ||
+  t.isExportSpecifier(path) ||
   t.isReturnStatement(path) ||
-  t.isVariableDeclarator(path) ||
-  t.isExportSpecifier(path)
+  t.isVariableDeclarator(path)
 
 export default isRemovablePath

--- a/src/removeExportSpecifier.js
+++ b/src/removeExportSpecifier.js
@@ -1,0 +1,13 @@
+import _ from 'lodash'
+
+const removeExportSpecifier = path => {
+  const parent = path.parentPath
+  const specifiers = _.get(parent, 'node.specifiers')
+
+  path.remove()
+
+  // Heads up! We should also remove ExportNamedDeclaration if it become empty
+  if (specifiers.length === 0) parent.remove()
+}
+
+export default removeExportSpecifier

--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -8,6 +8,7 @@ const removeReferences = (path, specifier) => {
 
   _.forEach(referencePaths, referencePath => {
     const parent = referencePath.findParent(isRemovablePath)
+    if (parent.removed) return
 
     if (t.isArrowFunctionExpression(parent)) {
       parent.get('body').remove()

--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -8,7 +8,6 @@ const removeReferences = (path, specifier) => {
 
   _.forEach(referencePaths, referencePath => {
     const parent = referencePath.findParent(isRemovablePath)
-    if (parent.removed) return
 
     if (parent.removed) return
     if (t.isArrowFunctionExpression(parent)) {

--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -2,8 +2,10 @@ import * as t from 'babel-types'
 import _ from 'lodash'
 
 import isRemovablePath from './isRemovablePath'
+import removeExportSpecifier from './removeExportSpecifier'
 
 const removeReferences = (path, specifier) => {
+  if (!path.scope.getBinding(specifier)) return
   const { referencePaths } = path.scope.getBinding(specifier)
 
   _.forEach(referencePaths, referencePath => {
@@ -12,6 +14,10 @@ const removeReferences = (path, specifier) => {
     if (parent.removed) return
     if (t.isArrowFunctionExpression(parent)) {
       parent.get('body').remove()
+      return
+    }
+    if (t.isExportSpecifier(parent)) {
+      removeExportSpecifier(parent)
       return
     }
     if (t.isVariableDeclarator(parent)) removeReferences(parent, _.get(parent, 'node.id.name'))

--- a/test/fixtures/export-default/expected.js
+++ b/test/fixtures/export-default/expected.js
@@ -1,0 +1,1 @@
+export doom from 'doom';

--- a/test/fixtures/export-default/fixture.js
+++ b/test/fixtures/export-default/fixture.js
@@ -1,0 +1,3 @@
+export assert from 'assert';
+export * as butter from 'butter';
+export default from 'cloud';

--- a/test/fixtures/export-default/fixture.js
+++ b/test/fixtures/export-default/fixture.js
@@ -1,3 +1,4 @@
 export assert from 'assert';
 export * as butter from 'butter';
 export default from 'cloud';
+export doom from 'doom';

--- a/test/fixtures/export-leftover/expected.js
+++ b/test/fixtures/export-leftover/expected.js
@@ -1,0 +1,3 @@
+import b from 'butter';
+
+export { b };

--- a/test/fixtures/export-leftover/fixture.js
+++ b/test/fixtures/export-leftover/fixture.js
@@ -1,0 +1,4 @@
+import a from 'assert';
+import b from 'butter';
+
+export { a, b };

--- a/test/fixtures/export/fixture.js
+++ b/test/fixtures/export/fixture.js
@@ -1,5 +1,4 @@
 import a, { b } from 'assert';
 
 export { default as c, d } from 'assert';
-
 export { a, b };

--- a/test/fixtures/export/fixture.js
+++ b/test/fixtures/export/fixture.js
@@ -1,0 +1,5 @@
+import a, { b } from 'assert';
+
+export { default as c, d } from 'assert';
+
+export { a, b };

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,7 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('declaration', { assert: ['default'] })
   testFixture('declaration-multiple', { assert: ['default'] })
   testFixture('export', { assert: ['default', 'b', 'd'] })
+  testFixture('export-leftover', { assert: ['default'] })
   testFixture('nested-calls', { assert: ['a', 'b'] })
   testFixture('nesting', { assert: ['default'] })
   testFixture('mixed', { assert: ['default', 'cloud'] })

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,7 @@ const testFixture = (name, imports, keepImports = false) =>
     ],
   ])
 
-describe('babel-plugin-filter-imports', function() {
+describe('babel-plugin-filter-imports', () => {
   testFixture('default', { assert: ['default'] })
   testFixture('named', { assert: ['a'] })
   testFixture('unnamed', { assert: ['assert'] })
@@ -42,6 +42,7 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('declaration', { assert: ['default'] })
   testFixture('declaration-multiple', { assert: ['default'] })
   testFixture('export', { assert: ['default', 'b', 'd'] })
+  testFixture('export-default', { assert: ['default'], butter: ['default'], cloud: ['default'] })
   testFixture('export-leftover', { assert: ['default'] })
   testFixture('nested-calls', { assert: ['a', 'b'] })
   testFixture('nesting', { assert: ['default'] })
@@ -63,9 +64,5 @@ describe('babel-plugin-filter-imports', function() {
   testFixtureWithPlugins('decorator', [
     [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
     'transform-decorators-legacy',
-  ])
-  testFixtureWithPlugins('export-default', [
-    [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
-    'babel-plugin-transform-export-extensions',
   ])
 })

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,7 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('callback', { assert: ['default'] })
   testFixture('declaration', { assert: ['default'] })
   testFixture('declaration-multiple', { assert: ['default'] })
+  testFixture('export', { assert: ['default', 'b', 'd'] })
   testFixture('nesting', { assert: ['default'] })
   testFixture('mixed', { assert: ['default', 'cloud'] })
   testFixture('return', { assert: ['default'] })

--- a/test/test.js
+++ b/test/test.js
@@ -63,4 +63,8 @@ describe('babel-plugin-filter-imports', function() {
     [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
     'transform-decorators-legacy',
   ])
+  testFixtureWithPlugins('export-default', [
+    [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
+    'babel-plugin-transform-export-extensions',
+  ])
 })


### PR DESCRIPTION
Adds the ability to remove export statements. The use case is when a function will be stripped from the external API of an addon and from the parent app, but other functions in the same module will not be. This allows an addon author to put the stripped code into a separate file to be removed at build time.

```js
export { default as shouldBeRemoved } from '-private/internals';

export function shouldNotBeRemoved() {
  // ...
}
```