### PR TITLE
fix(plugin): use `babel-plugin-syntax-decorators`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/ember-cli/babel-plugin-filter-imports",
   "dependencies": {
+    "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-types": "^6.26.0",
     "lodash": "^4.17.4"
   },
@@ -37,7 +38,6 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.26.0",
     "eslint": "^4.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import syntaxDecorators from 'babel-plugin-syntax-decorators'
 import _ from 'lodash'
 import path from 'path'
 
@@ -5,6 +6,8 @@ import getSpecifiersForRemoval from './getSpecifierNames'
 import removeReferences from './removeReferences'
 
 module.exports = () => ({
+  inherits: syntaxDecorators,
+
   visitor: {
     ImportDeclaration: (path, { opts }) => {
       const { imports, keepImports = false } = opts

--- a/test/fixtures/decorator/expected.js
+++ b/test/fixtures/decorator/expected.js
@@ -1,6 +1,7 @@
-let Assert = class Assert {
+class Assert {
   method() {}
 
   multiple() {}
-};
-let Butter = class Butter {};
+}
+
+class Butter {}

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,7 @@ describe('babel-plugin-filter-imports', function() {
   testFixture('callback', { assert: ['default'] })
   testFixture('declaration', { assert: ['default'] })
   testFixture('declaration-multiple', { assert: ['default'] })
+  testFixture('decorator', { assert: ['default'], butter: ['default'] })
   testFixture('nested-calls', { assert: ['a', 'b'] })
   testFixture('nesting', { assert: ['default'] })
   testFixture('mixed', { assert: ['default', 'cloud'] })
@@ -56,10 +57,5 @@ describe('babel-plugin-filter-imports', function() {
   testFixtureWithPlugins('multiple-instance', [
     [filterImports, { imports: { assert: ['default'] } }],
     [filterImports, { imports: { cloud: ['default'] } }],
-  ])
-
-  testFixtureWithPlugins('decorator', [
-    [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
-    'transform-decorators-legacy',
   ])
 })


### PR DESCRIPTION
Rel #25.

The correct way to get support of syntax is use [`inherits`](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#-enabling-syntax-in-plugins)