### PR TITLE
chore(package): remove useless and update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   },
   "homepage": "https://github.com/ember-cli/babel-plugin-filter-imports",
   "dependencies": {
-    "babel-plugin-syntax-export-extensions": "^6.13.0",
-    "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-types": "^6.26.0",
     "lodash": "^4.17.4"
   },
@@ -41,11 +39,11 @@
     "babel-eslint": "^8.0.1",
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.26.0",
-    "eslint": "^4.6.1",
+    "eslint": "^4.8.0",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-prettier": "^2.3.1",
-    "mocha": "^4.0.0",
-    "prettier": "^1.7.0",
+    "mocha": "^4.0.1",
+    "prettier": "^1.7.4",
     "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
`babel-plugin-syntax-export-extensions` and `babel-plugin-syntax-decorators` are useless as we don't use `inherits`. Also, updates other deps.