### PR TITLE
fix(plugin): use legacy decorator plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import removeReferences from './removeReferences'
 
 module.exports = () => ({
   manipulateOptions: (opts, parserOptions) => {
-    parserOptions.plugins.push(['decorators', { decoratorsBeforeExport: true }])
+    parserOptions.plugins.push(['decorators', { decoratorsBeforeExport: true, legacy: true }])
     parserOptions.plugins.push('exportDefaultFrom')
     parserOptions.plugins.push('exportNamespaceFrom')
   },


### PR DESCRIPTION
I came across the fact that this behavior changed when trying to upgrade `@ember-decorators/argument` to use Babel 7. A problem arose from the fact that this was providing the non-legacy decorators plugin, while that package provided the legacy one.

I think that it makes more sense that the legacy behavior would be used for decorators, since that's how most of the decorators in the Ember ecosystem are implemented right now.

Alternatively, allowing a user fo the plugin to specify which version they want, or looking for an existing `decorators` instance before going ahead and adding to the `plugin` list, would be reasonable approaches as well.
