### PR TITLE
breaking(plugin): stop adding the `decorators` option into Babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@babel/cli": "^7.1.5",
     "@babel/core": "^7.4.0",
+    "@babel/plugin-proposal-decorators": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
     "@babel/register": "^7.4.0",
     "babel-eslint": "^10.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import removeReferences from './removeReferences'
 
 module.exports = () => ({
   manipulateOptions: (opts, parserOptions) => {
-    parserOptions.plugins.push(['decorators', { decoratorsBeforeExport: true, legacy: true }])
     parserOptions.plugins.push('exportDefaultFrom')
     parserOptions.plugins.push('exportNamespaceFrom')
   },

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,6 @@ describe('babel-plugin-filter-imports', () => {
   testFixture('callback', { assert: ['default'] })
   testFixture('declaration', { assert: ['default'] })
   testFixture('declaration-multiple', { assert: ['default'] })
-  testFixture('decorator', { assert: ['default'], butter: ['default'] })
   testFixture('export', { assert: ['default', 'b', 'd'] })
   testFixture('export-default', { assert: ['default'], butter: ['default'], cloud: ['default'] })
   testFixture('export-leftover', { assert: ['default'] })
@@ -61,5 +60,10 @@ describe('babel-plugin-filter-imports', () => {
   testFixtureWithPlugins('multiple-instance', [
     [filterImports, { imports: { assert: ['default'] } }, 'assert'],
     [filterImports, { imports: { cloud: ['default'] } }, 'cloud'],
+  ])
+
+  testFixtureWithPlugins('decorator', [
+    [filterImports, { imports: { assert: ['default'], butter: ['default'] } }],
+    ['@babel/plugin-proposal-decorators', { legacy: true }],
   ])
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,18 @@
     "@babel/traverse" "^7.4.0"
     "@babel/types" "^7.4.0"
 
+"@babel/helper-create-class-features-plugin@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz#30fd090e059d021995c1762a5b76798fa0b51d82"
+  integrity sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.4.0"
+    "@babel/helper-split-export-declaration" "^7.4.0"
+
 "@babel/helper-define-map@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz#cbfd8c1b2f12708e262c26f600cd16ed6a3bc6c9"
@@ -261,6 +273,15 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
+"@babel/plugin-proposal-decorators@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.0.tgz#8e1bfd83efa54a5f662033afcc2b8e701f4bb3a9"
+  integrity sha512-d08TLmXeK/XbgCo7ZeZ+JaeZDtDai/2ctapTRsWWkkmy7G/cqz8DQN/HlWG7RR4YmfXxmExsbU3SuCjlM7AtUg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.4.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-decorators" "^7.2.0"
+
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
@@ -298,6 +319,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
   integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-decorators@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz#c50b1b957dcc69e4b1127b65e1c33eef61570c1b"
+  integrity sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
In the most recent versions of `ember-cli-babel` we started including
the legacy decorators transform by default. When used with this plugin,
this causes breakage, because both plugins are adding _conflicting_
internal babel plugins.

In general, this is problematic, because the `filter-imports` plugin is
making assumptions about which version of decorators will be used. It
would instead make more sense to allow the user to choose which version
they want by adding and configuring the
`@babel/plugin-proposal-decorators` package themselves.

This PR removes the plugin, and adds the proposal package for local
testing. Users of the package _should_ already be required to add the
decorators transform if they are filtering decorators, so this shouldn't
be an issue in general, but this is _technically_ breaking so I think it
would make sense to bump a major version.