### PR TITLE
[BUGFIX] Remove decorators from the AST if there are no more decorators

### DIFF
--- a/src/removeReferences.js
+++ b/src/removeReferences.js
@@ -22,7 +22,16 @@ const removeReferences = (path, specifier) => {
     }
     if (t.isVariableDeclarator(removalPath))
       removeReferences(removalPath, _.get(removalPath, 'node.id.name'))
+    
     removalPath.remove()
+    
+    if (t.isDecorator(removalPath)) {
+      let decorators = removalPath.parentPath.node.decorators
+
+      if (decorators && decorators.length === 0) {
+        removalPath.parentPath.node.decorators = undefined
+      }
+    }
   })
 }
 


### PR DESCRIPTION
Currently I'm encountering a failure caused by this plugin when trying to remove method decorators, _specifically_ if it is removing the only decorator on the method:

```
 Method has decorators, put the decorator plugin before the classes one.
   7 | class AbstractClass {
   8 |   @abstract field;
>  9 |   @abstract method() {}
     |   ^
  10 | }
  11 | 
  12 | module('@abstract', () => {
```

This fixes this issue by removing the array altogether if no decorators exist after removal.